### PR TITLE
Ensure errors pass in ServerMode

### DIFF
--- a/moto/databrew/responses.py
+++ b/moto/databrew/responses.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 from moto.core.responses import BaseResponse
 from moto.core.utils import amzn_request_id
+from .exceptions import DataBrewClientError
 from .models import databrew_backends
 
 
@@ -57,7 +58,12 @@ class DataBrewResponse(BaseResponse):
 
         recipe_name = parsed_url.path.rstrip("/").rsplit("/", 1)[1]
 
-        return json.dumps(self.databrew_backend.get_recipe(recipe_name, None).as_dict())
+        try:
+            return json.dumps(
+                self.databrew_backend.get_recipe(recipe_name, None).as_dict()
+            )
+        except DataBrewClientError as e:
+            return e.code, e.get_headers(), e.get_body()
 
 
 # 'DescribeRecipe'

--- a/tests/test_databrew/test_databrew.py
+++ b/tests/test_databrew/test_databrew.py
@@ -5,7 +5,6 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_databrew
-from moto.databrew.exceptions import RecipeNotFoundException
 
 
 def _create_databrew_client():
@@ -101,10 +100,11 @@ def test_describe_recipe():
 def test_describe_recipe_that_does_not_exist():
     client = _create_databrew_client()
 
-    with pytest.raises(RecipeNotFoundException) as exc:
+    with pytest.raises(ClientError) as exc:
         client.describe_recipe(Name="DoseNotExist")
-
-    exc.value.message.should.equal("Recipe DoseNotExist not found.")
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("EntityNotFoundException")
+    err["Message"].should.equal("Recipe DoseNotExist not found.")
 
 
 @mock_databrew


### PR DESCRIPTION
Hi @shield007, I went on a debugging spree to figure out why the tests in ServerMode were failing, and fixing it was quite simple at the end, so I figured I would just create a PR instead!

The `test_describe_recipe_that_does_not_exist` test was failing in ServerMode, because it expected the wrong kind of exception. In ServerMode, all error responses thrown are automatically  converted into type `botocore.exceptions.ClientError`, so we should expect those as well.

In order to ensure that Moto returns the error response in the correct format, I also added the try-catch around `describe_recipe_response`.
(The `dispatch`-method automatically converts any errors from the other methods, but because we're intercepting the request manually in `describe_recipe_response`, we also have to convert the error responses manually.)

With these changes the build should pass.